### PR TITLE
Fix Q136: Preemption does not respect PDBs

### DIFF
--- a/KCNA/01-kubernetes-fundamentals/02-administration.md
+++ b/KCNA/01-kubernetes-fundamentals/02-administration.md
@@ -3158,9 +3158,9 @@ D) It scales down other deployments
 
 **Answer:** B
 
-**Explanation:** When a high-priority Pod can't be scheduled due to resource constraints, the scheduler may preempt (evict) lower-priority Pods to make room. Preemption respects PodDisruptionBudgets and graceful termination periods where possible.
+**Explanation:** When a high-priority Pod can't be scheduled due to resource constraints, the scheduler may preempt (evict) lower-priority Pods to make room. Preemption can evict pods regardless of PodDisruptionBudgets (PDBs apply to voluntary disruptions, not scheduler preemption), though it honors graceful termination periods.
 
-**Source:** [Command line tool (kubectl) | Kubernetes](https://kubernetes.io/docs/reference/kubectl/)
+**Source:** [Pod Priority and Preemption | Kubernetes](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/)
 
 </details>
 


### PR DESCRIPTION
## Summary
- Q136: Corrected explanation about preemption and PodDisruptionBudgets
- PDBs apply to voluntary disruptions (eviction API), not scheduler preemption
- Preemption can evict lower-priority pods regardless of PDBs
- Updated source to official Pod Priority and Preemption docs

## Test plan
- [ ] Verify against https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/

🤖 Generated with [Claude Code](https://claude.com/claude-code)