### PR TITLE
Fix Q9, Q30, Q98 in security MCQs (round 12)

### DIFF
--- a/KCNA/02-container-orchestration/02a-security.md
+++ b/KCNA/02-container-orchestration/02a-security.md
@@ -686,7 +686,7 @@ What Linux capabilities are dropped by the "restricted" Pod Security Standard?
 
 A) Only NET_RAW
 B) Only SYS_ADMIN
-C) ALL capabilities must be dropped; only NET_BIND_SERVICE may be added back
+C) ALL capabilities must be dropped; no capabilities may be added back
 D) No capabilities are dropped
 
 <details>
@@ -694,7 +694,7 @@ D) No capabilities are dropped
 
 **Answer:** C
 
-**Explanation:** The restricted Pod Security Standard requires that ALL capabilities be dropped via capabilities.drop. The only capability that may be added back is NET_BIND_SERVICE (to allow binding to privileged ports without full root). Any other capability in capabilities.add violates the restricted profile.
+**Explanation:** The restricted Pod Security Standard requires that ALL capabilities be dropped via capabilities.drop, and no capabilities may be added back (capabilities.add must be undefined/nil). This is more restrictive than the baseline profile, which allows adding certain safe capabilities like NET_BIND_SERVICE.
 
 **Source:** [Pod Security Standards | Kubernetes](https://kubernetes.io/docs/concepts/security/pod-security-standards/)
 

--- a/KCNA/02-container-orchestration/02b-security.md
+++ b/KCNA/02-container-orchestration/02b-security.md
@@ -207,7 +207,7 @@ D) read-only
 
 **Answer:** B
 
-**Explanation:** The "view" ClusterRole is a default aggregated role that grants read-only access to most objects in a namespace (excluding secrets and role bindings). It's designed for non-destructive access, allowing users to see resources without modifying them.
+**Explanation:** The "view" ClusterRole is a default aggregated role that grants read-only access to most objects in a namespace (excluding Secrets). It's designed for non-destructive access, allowing users to see resources without modifying them.
 
 **Source:** [Using RBAC Authorization | Kubernetes](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles)
 
@@ -696,7 +696,7 @@ D) Modify the API server binary
 
 **Explanation:** Cluster-wide Pod Security Admission defaults can be configured by providing an AdmissionConfiguration file to the API server with the --admission-control-config-file flag. This sets default policies, exemptions, and audit settings that apply when namespaces don't have explicit labels.
 
-**Source:** [Pod Security Admission | Kubernetes](https://kubernetes.io/docs/concepts/security/pod-security-admission/#pod-security-admission-labels-for-namespaces)
+**Source:** [Pod Security Admission | Kubernetes](https://kubernetes.io/docs/concepts/security/pod-security-admission/#configure-the-admission-controller)
 
 </details>
 
@@ -2258,21 +2258,21 @@ D) By managing container images
 ### Question 98
 [HARD]
 
-Why should you use image digests instead of tags?
+How does imagePullPolicy interact with image tags versus digests?
 
-A) Digests are shorter
-B) Digests are immutable and guarantee you get the exact same image content
-C) Tags are deprecated
-D) Digests improve pull speed
+A) imagePullPolicy has no effect on digests
+B) IfNotPresent always pulls digests but caches tags
+C) With :latest tag, imagePullPolicy defaults to Always; with digests or specific tags, it defaults to IfNotPresent
+D) Digests force Always pull policy regardless of setting
 
 <details>
 <summary>Show Answer</summary>
 
-**Answer:** B
+**Answer:** C
 
-**Explanation:** Image digests (e.g., image@sha256:abc123...) are immutable and uniquely identify specific image content. Unlike tags which can be moved to point to different images, digests guarantee you always pull the exact same image. This prevents unexpected changes when a tag is updated and improves security and reproducibility.
+**Explanation:** When using the :latest tag, Kubernetes defaults imagePullPolicy to Always, pulling the image on every Pod start. For images with specific version tags or digests, the default is IfNotPresent, only pulling if the image isn't cached locally. Since digests are immutable, IfNotPresent is safe—the cached image is guaranteed to match. With mutable tags like :latest, Always ensures you get the current version.
 
-**Source:** [Images | Kubernetes](https://kubernetes.io/docs/concepts/containers/images/#image-names)
+**Source:** [Images | Kubernetes](https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy)
 
 </details>
 


### PR DESCRIPTION
## Summary
- **02b Q9**: Remove "role bindings" from view ClusterRole explanation - official docs only specify that view excludes Secrets, not RoleBindings
- **02a Q30**: Fix restricted profile capabilities - restricted requires dropping ALL capabilities and does NOT allow adding any back (not even NET_BIND_SERVICE, which is only allowed in baseline)
- **02b Q30**: Update source link from namespace labels section to admission controller config section
- **02b Q98**: Change duplicate tag vs digest question to cover imagePullPolicy interaction with tags/digests

## Test plan
- [ ] Verify Q9 explanation matches official RBAC docs
- [ ] Verify Q30 (02a) matches Pod Security Standards restricted profile
- [ ] Verify Q30 (02b) source link goes to correct documentation section
- [ ] Verify Q98 is now distinct from Q90

🤖 Generated with [Claude Code](https://claude.com/claude-code)