### PR TITLE
Fix Q170 probe timing formula in 03b-troubleshooting.md (round 3)

### DIFF
--- a/KCNA/02-container-orchestration/03b-troubleshooting.md
+++ b/KCNA/02-container-orchestration/03b-troubleshooting.md
@@ -1622,7 +1622,7 @@ D) Network issues
 
 **Answer:** B
 
-**Explanation:** Predictable restart intervals suggest probe timing issues. Calculate: `initialDelaySeconds + (failureThreshold × periodSeconds)`. If restarts match this, the probe fails before the app is truly ready or responsive. Adjust timing or add startupProbe for slow apps.
+**Explanation:** Predictable restart intervals suggest probe timing issues. Calculate: `initialDelaySeconds + ((failureThreshold - 1) × periodSeconds)`. For example, with defaults (initialDelaySeconds=0, periodSeconds=10, failureThreshold=3), restart occurs at 20 seconds. If restarts match this calculation, the probe fails before the app is truly ready. Adjust timing or add startupProbe for slow apps.
 
 **Source:** [Configure Liveness, Readiness and Startup Probes | Kubernetes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)
 


### PR DESCRIPTION
## Summary
- **Q170**: Fixed off-by-one error in probe timing formula

The formula for calculating time until liveness probe triggers restart was incorrect:
- **Wrong:** `initialDelaySeconds + (failureThreshold × periodSeconds)`
- **Correct:** `initialDelaySeconds + ((failureThreshold - 1) × periodSeconds)`

With defaults (initialDelaySeconds=0, periodSeconds=10, failureThreshold=3):
- Probe runs at t=0 (fail 1), t=10 (fail 2), t=20 (fail 3 → restart)
- Correct answer: 20 seconds, not 30 seconds

## Test plan
- [ ] Verify the formula correctly calculates `0 + (3-1) × 10 = 20 seconds` for default values
- [ ] Verify explanation makes sense with the added example

🤖 Generated with [Claude Code](https://claude.com/claude-code)