### PR TITLE
Fix Q67 (3a), Q32 (3b), Q61 (3b) accuracy issues (round 16)

### DIFF
--- a/KCNA/02-container-orchestration/03a-troubleshooting.md
+++ b/KCNA/02-container-orchestration/03a-troubleshooting.md
@@ -1544,7 +1544,7 @@ D) Volume is read-only
 How do you troubleshoot imagePullSecrets not working?
 
 A) Delete the image
-B) Verify Secret exists, is type dockerconfigjson, is in same namespace, and check registry credentials
+B) Verify Secret exists, is type dockerconfigjson or dockercfg, is in same namespace, and check registry credentials
 C) Change registry
 D) Remove Secret
 
@@ -1553,7 +1553,7 @@ D) Remove Secret
 
 **Answer:** B
 
-**Explanation:** imagePullSecrets issues: 1) Secret must exist in same namespace as Pod, 2) Type must be `kubernetes.io/dockerconfigjson`, 3) Credentials must be valid for the registry, 4) Check Secret is referenced in Pod spec or ServiceAccount, 5) Events show auth failures.
+**Explanation:** imagePullSecrets issues: 1) Secret must exist in same namespace as Pod, 2) Type should be `kubernetes.io/dockerconfigjson` (recommended) or legacy `kubernetes.io/dockercfg`, 3) Credentials must be valid for the registry, 4) Check Secret is referenced in Pod spec or ServiceAccount, 5) Events show auth failures.
 
 **Source:** [Pull an Image from a Private Registry | Kubernetes](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/)
 

--- a/KCNA/02-container-orchestration/03b-troubleshooting.md
+++ b/KCNA/02-container-orchestration/03b-troubleshooting.md
@@ -733,16 +733,16 @@ D) Service doesn't exist
 How do you verify if a Service selector matches any Pods?
 
 A) kubectl describe service
-B) kubectl get endpoints <service-name>
+B) kubectl get pods -l <selector-labels>
 C) kubectl get pods --show-labels
-D) Both A and B work, but B shows actual Pod IPs
+D) kubectl get endpoints <service-name>
 
 <details>
 <summary>Show Answer</summary>
 
-**Answer:** D
+**Answer:** B
 
-**Explanation:** `kubectl describe service` shows selector and endpoint IPs. `kubectl get endpoints <service-name>` directly shows which Pod IPs are registered as endpoints. If endpoints list is empty, the selector doesn't match any Ready Pods. Both work, but endpoints show concrete addresses.
+**Explanation:** To verify selector matching, use `kubectl get pods -l <selector>` which shows all Pods matching the selector regardless of Ready state. Endpoints (`kubectl get endpoints`) only include Ready Pods by default, so empty endpoints could mean Pods exist but aren't Ready, not that the selector doesn't match. Check selector first, then endpoints to verify Pod readiness.
 
 **Source:** [Debug Services | Kubernetes](https://kubernetes.io/docs/tasks/debug/debug-application/debug-service/)
 
@@ -1406,7 +1406,7 @@ D) Scale to 0
 What happens if a ConfigMap referenced by a Pod doesn't exist?
 
 A) Pod uses default values
-B) Pod fails to start with CreateContainerConfigError
+B) Pod won't start - behavior depends on usage type
 C) ConfigMap is created automatically
 D) Pod starts without the ConfigMap data
 
@@ -1415,7 +1415,7 @@ D) Pod starts without the ConfigMap data
 
 **Answer:** B
 
-**Explanation:** If a required ConfigMap doesn't exist, the Pod cannot start and shows `CreateContainerConfigError` status. This applies to ConfigMaps mounted as volumes or used for environment variables. Mark ConfigMap reference as optional to allow Pod startup without it.
+**Explanation:** If a required ConfigMap doesn't exist, the Pod won't start, but the behavior differs by usage: for ConfigMap volumes, the Pod stays Pending with mount errors; for environment variable references (envFrom or valueFrom), the container fails with `CreateContainerConfigError`. Mark ConfigMap reference as optional to allow Pod startup without it.
 
 **Source:** [ConfigMaps | Kubernetes](https://kubernetes.io/docs/concepts/configuration/configmap/)
 


### PR DESCRIPTION
## Summary
- Q67 (3a): Include legacy `kubernetes.io/dockercfg` for imagePullSecrets (both types are supported)
- Q32 (3b): Change answer to selector-based pod list (`kubectl get pods -l <selector>`) since Endpoints only show Ready Pods
- Q61 (3b): Distinguish ConfigMap volume behavior (Pod stays Pending) vs env var refs (CreateContainerConfigError)

## Test plan
- [x] Verify markdown formatting is correct
- [x] Verify answer keys match explanations

🤖 Generated with [Claude Code](https://claude.com/claude-code)